### PR TITLE
Fix error and add option to Consul inventory script

### DIFF
--- a/inventory/consul_io.ini
+++ b/inventory/consul_io.ini
@@ -54,4 +54,4 @@ available_suffix = _up
 unavailable_suffix = _down
 
 # if true then parse node name to ip
-node_to_ip = true
+node_to_ip = false

--- a/inventory/consul_io.ini
+++ b/inventory/consul_io.ini
@@ -52,3 +52,6 @@ kv_metadata=ansible/metadata
 availability = true
 available_suffix = _up
 unavailable_suffix = _down
+
+# if true then parse node name to ip
+node_to_ip = true

--- a/inventory/consul_io.py
+++ b/inventory/consul_io.py
@@ -144,6 +144,7 @@ be used to access the machine.
 'node_to_ip'
 
 if true then the node would be parsed as ip address. Else would keep using node name.
+This can also be set with the env. variable CONSUL_NODE_TO_IP
 ```
 
 '''


### PR DESCRIPTION
## SUMMARY

* Add option 'node_to_ip'
* At **load_data_for_node()**, should not determinate whether to load from memory by 'suffixes'
* At **load_data_for_node()**, still load from service when 'suffixes' is not set

## DEMO
With following instances
![image](https://user-images.githubusercontent.com/21155445/131159910-08991ffa-5881-4ba1-a54a-fc596c1403b1.png)
### ASIS
with following consul.ini
```ini
# Ansible Consul external inventory script settings.

[consul]

#
# Bulk load. Load all possible data before building inventory JSON
# If true, script processes in-memory data. JSON generation reduces drastically
#
bulk_load = false

# restrict included nodes to those from this datacenter
#datacenter = nyc1

# url of the consul cluster to query
#url = http://demo.consul.io
url = http://localhost:8500

# suffix added to each service to create a group name e.g Service of 'redis' and
# a suffix of '_servers' will add each address to the group name 'redis_servers'
#servers_suffix = _servers

#
# By default, final JSON is built based on all available info in consul.
# Suffixes means that services groups will be added in addition to basic information. See servers_suffix for additional info
# There are cases when speed is preferable than having services groups
# False value will reduce script execution time drastically.
#
#suffixes = true

# if specified then the inventory will generate domain names that will resolve
# via Consul's inbuilt DNS. 
#domain=consul

# make groups from service tags. the name of the group is derived from the
# service name and the tag name e.g. a service named nginx with tags ['master', 'v1']
# will create groups nginx_master and nginx_v1
tags = true

# looks up the node name at the given path for a list of groups to which the
# node should be added.
kv_groups=ansible/groups

# looks up the node name at the given path for a json dictionary of metadata that
# should be attached as metadata for the node
kv_metadata=ansible/metadata

# looks up the health of each service and adds the node to 'up' and 'down' groups
# based on the service availability
#
# !!!! if availability is true, suffixes also must be true. !!!!
#
#availability = true
available_suffix = _up
unavailable_suffix = _down

# if true then parse node name to ip
node_to_ip = true
```
Result of parsing inventory
```bash
(venv) root@92da416898e2:/app/contrib-scripts# python3 inventory/consul_io.py --list
inventory/consul_io.py:478: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  config = configparser.SafeConfigParser()
Traceback (most recent call last):
  File "inventory/consul_io.py", line 553, in <module>
    ConsulInventory()
  File "inventory/consul_io.py", line 244, in __init__
    self.load_all_data_consul()
  File "inventory/consul_io.py", line 264, in load_all_data_consul
    self.load_data_for_datacenter(datacenter)
  File "inventory/consul_io.py", line 309, in load_data_for_datacenter
    self.load_data_for_node(node['Node'], datacenter)
  File "inventory/consul_io.py", line 318, in load_data_for_node
    node_data = self.consul_get_node_inmemory(node)
  File "inventory/consul_io.py", line 299, in consul_get_node_inmemory
    return {"Node": result.pop(), "Services": {}} if result else None
AttributeError: 'filter' object has no attribute 'pop'
```
### TOBE
After change, same ini file with comment out 'node_to_ip'
```bash
(venv) root@92da416898e2:/app/contrib-scripts# python3 inventory/consul_io.py --list
inventory/consul_io.py:486: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  config = configparser.SafeConfigParser()
{
  "_meta": {
    "hostvars": {
      "192.168.144.2": {
        "consul_datacenter": "dc1",
        "consul_nodename": "server-1",
        "consul_services": [
          "consul"
        ]
      },
      "192.168.144.3": {
        "consul_datacenter": "dc1",
        "consul_nodename": "client-2",
        "consul_services": [
          "consul"
        ]
      },
      "192.168.144.4": {
        "consul_datacenter": "dc1",
        "consul_nodename": "client-1",
        "consul_services": [
          "consul"
        ]
      }
    }
  },
  "all": [
    "192.168.144.2",
    "192.168.144.3",
    "192.168.144.4"
  ],
  "consul": [
    "192.168.144.2",
    "192.168.144.3",
    "192.168.144.4"
  ],
  "dc1": [
    "192.168.144.2",
    "192.168.144.3",
    "192.168.144.4"
  ]
}


```