### PR TITLE
Drop everything below Python 3.9 from CI

### DIFF
--- a/.github/workflows/pythonlinters.yml
+++ b/.github/workflows/pythonlinters.yml
@@ -15,18 +15,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.7'
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
         container:
           - ubuntu-latest
-        include:
-          - python-version: 2.7
-            container: ubuntu-20.04
-          - python-version: 3.6
-            container: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3

--- a/ci-constraints.txt
+++ b/ci-constraints.txt
@@ -1,4 +1,1 @@
-flake8 < 4.0.0 ; python_version < '3.7'
-flake8 < 6.0.0 ; python_version < '3.8'
-pylint < 2.0.0 ; python_version < '3.0'
-pylint <= 2.6.1 ; python_version < '3.6'
+# Add package constraints here for CI (like for pylint and flake8).


### PR DESCRIPTION
The current ansible-core releases require Python 3.9+, and these scripts run on the controller.